### PR TITLE
Bug Fix : Failure when executing SQL string  #7

### DIFF
--- a/ReliableDbProvider.Tests/DbProviderTestBase.cs
+++ b/ReliableDbProvider.Tests/DbProviderTestBase.cs
@@ -38,6 +38,22 @@ namespace ReliableDbProvider.Tests
                 Assert.That(dbUser.Name, Is.EqualTo(user.Name));
             }
         }
+
+        [Test]
+        public void Insert_and_select_entity_with_custom_sql()
+        {
+            using (var context = GetContext())
+            using (var context2 = GetContext())
+            {
+                var user = new User { Name = "Name" };
+                context.Users.Add(user);
+                context.SaveChanges();
+
+                var dbUser = context2.Database.SqlQuery<User>("select * from [user] where Id = '" + user.Id + "'").FirstOrDefault();
+
+                Assert.That(dbUser.Name, Is.EqualTo(user.Name));
+            }
+        }
         
         [Test]
         public void Insert_and_select_multiple_entities()

--- a/ReliableDbProvider/ReliableDbProvider.csproj
+++ b/ReliableDbProvider/ReliableDbProvider.csproj
@@ -76,6 +76,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReliableDbProviderServices.cs" />
+    <Compile Include="ReliableSqlDbTransaction.cs" />
     <Compile Include="ReliableSqlClientProvider.cs" />
     <Compile Include="ReliableSqlCommand.cs">
       <SubType>Component</SubType>

--- a/ReliableDbProvider/ReliableSqlDbConnection.cs
+++ b/ReliableDbProvider/ReliableSqlDbConnection.cs
@@ -58,7 +58,9 @@ namespace ReliableDbProvider
             {
                 if (ReliableConnection.State != ConnectionState.Open)
                     ReliableConnection.Open();
-                return (DbTransaction) ReliableConnection.BeginTransaction(isolationLevel);
+
+                var transaction = (SqlTransaction)ReliableConnection.BeginTransaction(isolationLevel);                
+                return new ReliableSqlDbTransaction(this, transaction);
             });
         }
 
@@ -95,7 +97,7 @@ namespace ReliableDbProvider
 
         protected override DbCommand CreateDbCommand()
         {
-            return new ReliableSqlCommand(ReliableConnection.CreateCommand());
+            return new ReliableSqlCommand(this, ReliableConnection.CreateCommand());
         }
 
         public override void Open()

--- a/ReliableDbProvider/ReliableSqlDbTransaction.cs
+++ b/ReliableDbProvider/ReliableSqlDbTransaction.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Data;
+using System.Data.Common;
+using System.Data.SqlClient;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReliableDbProvider
+{
+    /// <summary>
+    /// This class just wraps a Dbtransaction and prevents our SqlConnection from being leaked to the outside world
+    /// </summary>
+    public class ReliableSqlDbTransaction : DbTransaction
+    {
+        readonly ReliableSqlDbConnection innerConnection;
+        readonly SqlTransaction innerTransaction;
+
+        internal SqlTransaction InnerTransaction { get { return innerTransaction; } }
+
+        public ReliableSqlDbTransaction(ReliableSqlDbConnection connection,  SqlTransaction transaction)
+        {
+            this.innerConnection = connection;
+            this.innerTransaction = transaction;
+        }
+        public override void Commit()
+        {
+            innerTransaction.Commit();
+        }
+
+        protected override DbConnection DbConnection
+        {
+            get { return innerConnection; }
+        }
+
+        public override System.Data.IsolationLevel IsolationLevel
+        {
+            get { return innerTransaction.IsolationLevel; }
+        }
+
+        public override void Rollback()
+        {
+            innerTransaction.Rollback();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            innerTransaction.Dispose();
+            base.Dispose(disposing);
+        }
+       
+    }
+}


### PR DESCRIPTION
The reason for this code failing was that the **ReliableConnection** of the Command was not being set in the constructor when the **ReliableSqlDbComand** was being constructed with a command that already has an associated Connection. To overcome this issue i have added a second constructor that takes a, SQLCommand and a ReliableSqlDbConnection _(Which is just the wrapped version of the existing commands connection)_.

```
    //Bug Fix: Failure when executing SQL string
    public ReliableSqlCommand(ReliableSqlDbConnection connection, SqlCommand commandToWrap) 
    {
        this.Current = commandToWrap;
        this.ReliableDbConnection = connection;
        this.ReliableConnection = (connection==null) ? null : connection.ReliableConnection;
    }
```

Also added a wrapper for transaction as returning a SqlTransaction allows a SQL connection to be leaked out of this wrapper.
This causes problems when using other API's such as EnterpriseLibrary.Data, as the leaked SQLConnection meant that the API had access to and used a _non-reliable_ SqlConnection.
